### PR TITLE
Remove unnecessary teleport flag in DSDFarmTask

### DIFF
--- a/src/tasks/DSDFarmTask.py
+++ b/src/tasks/DSDFarmTask.py
@@ -199,7 +199,6 @@ class DSDFarmTask(NTEOneTimeTask, BaseCombatTask):
             self.deside_combat_action()
         self.sleep(0.5)
         box = self.box_of_screen(0.410, 0.234, 0.560, 0.556)
-        self.do_teleport_on_spot = True
         self.ensure_teleport(lambda: self.teleport_to_top_bonfire(box))
 
     def ensure_teleport(self, fun):


### PR DESCRIPTION
Probably some AI hallucinated leftover code. 

Because of that line it teleports twice to that bonfire.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug 修复**
  * 调整特定地点的传送流程，避免执行额外的“传送到点位”步骤。
  * 保留前往目标篝火的传送控制，提升任务执行的稳定性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->