### PR TITLE
feat(combat): multi-direction enemy search in target_enemy

### DIFF
--- a/src/combat/CombatCheck.py
+++ b/src/combat/CombatCheck.py
@@ -165,18 +165,32 @@ class CombatCheck(BaseNTETask):
         time_out = self.target_enemy_time_out
         if turn:
             # 引入了转向，需要额外增加耗时，原本的时间不足以完成
-            time_out += 2.5
+            time_out += 5.0
         logger.info(f"targeting enemy for {time_out}s")
         deadline = time.time() + time_out
+        # Multi-direction search: turn left, turn right, walk forward, back up.
+        # A single direction (old: only "a") misses enemies that moved behind
+        # or to the side of the character during combat.
+        search_actions = [
+            ("a", 0.15),
+            ("a", 0.15),
+            ("d", 0.15),
+            ("d", 0.15),
+            ("w", 0.5),
+            ("s", 0.3),
+        ]
+        search_idx = 0
         while time.time() < deadline:
             if self.is_in_team():
                 if self.wait_until(lambda: self.combat_detect(lv=lv), time_out=0.2):
                     return True
                 if turn:
-                    self.send_key("a", down_time=0.1)
-                    self.sleep(0.3)
+                    key, dur = search_actions[search_idx % len(search_actions)]
+                    self.send_key(key, down_time=dur)
+                    self.sleep(0.2)
                     self.middle_click()
-                    self.sleep(0.3)
+                    self.sleep(0.2)
+                    search_idx += 1
                 else:
                     self.middle_click()
                     self.sleep(0.3)

--- a/src/combat/CombatCheck.py
+++ b/src/combat/CombatCheck.py
@@ -168,16 +168,15 @@ class CombatCheck(BaseNTETask):
             time_out += 5.0
         logger.info(f"targeting enemy for {time_out}s")
         deadline = time.time() + time_out
-        # Multi-direction search: turn left, turn right, walk forward, back up.
-        # A single direction (old: only "a") misses enemies that moved behind
-        # or to the side of the character during combat.
+        # Sweep rotation left then right to re-acquire a target that moved out
+        # of view during combat. Rotating covers enemies behind or to the side
+        # of the character; alternating the direction avoids spinning endlessly
+        # one way and handles walls on either side.
         search_actions = [
             ("a", 0.15),
             ("a", 0.15),
             ("d", 0.15),
             ("d", 0.15),
-            ("w", 0.5),
-            ("s", 0.3),
         ]
         search_idx = 0
         while time.time() < deadline:


### PR DESCRIPTION
## Camera Settings Dependency

The search sweeps the camera left and right (A / D) to re-acquire a target that drifted out of view during combat. Turning is camera-relative, so it assumes the standard camera settings from the README:

- **Movement Camera Correction (移动镜头修正)**: Disabled
- **Press to Reset Camera (按下锁定镜头回正)**: Enabled

With these settings, the left / right sweep reliably covers enemies behind or to the side of the character without moving it out of position. The search alternates directions instead of spinning only one way (the original code pressed only A), which also handles walls on either side.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug 修复**
  - 改进启用回合模式时的敌人目标搜索流程。
  - 延长目标搜索超时时间，提升复杂场景下的识别成功率。
  - 优化移动、点击与等待节奏，增强战斗操作的稳定性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->