### PR TITLE
fix: preserve error details in logging paths

### DIFF
--- a/src/YOLO26OpenVINOAsyncDetector.py
+++ b/src/YOLO26OpenVINOAsyncDetector.py
@@ -257,7 +257,7 @@ class YOLO26OpenVINOAsyncDetector:
             if result_holder is not None:
                 result_holder["results"] = tmp_results
         except Exception as e:
-            logger.error("openvino callback ignored failed/cancelled task", e)
+            logger.error("openvino callback ignored failed/cancelled task: %s", e)
         finally:
             if request_id is not None:
                 self._mark_request_job_finished(request_id)

--- a/src/audio_routing.py
+++ b/src/audio_routing.py
@@ -84,7 +84,7 @@ def open_svcl_download_page(*_args, **_kwargs) -> None:
 
         QDesktopServices.openUrl(QUrl(SVCL_URL))
     except Exception as exc:
-        logger.error("failed to open SoundVolumeCommandLine download page", exc)
+        logger.error("failed to open SoundVolumeCommandLine download page: %s", exc)
         _alert_error("Failed to open SoundVolumeCommandLine download page")
 
 
@@ -526,7 +526,7 @@ class _BackgroundAudioRouter:
                 creationflags=subprocess.CREATE_NO_WINDOW
             )
         except Exception as exc:
-            logger.error("failed to route game audio with svcl", exc)
+            logger.error("failed to route game audio with svcl: %s", exc)
             return ""
         if result.returncode != 0:
             logger.warning(f"svcl audio route failed with exit code {result.returncode}")

--- a/tests/TestYOLO26OpenVINOAsyncDetector.py
+++ b/tests/TestYOLO26OpenVINOAsyncDetector.py
@@ -103,6 +103,24 @@ class TestYOLO26OpenVINOAsyncDetector(unittest.TestCase):
     def test_numpy_fallback_accepts_avx2_on_old_windows(self, _windows_supports, _numpy_supports):
         self.assertTrue(YOLO26OpenVINOAsyncDetector._supports_avx2())
 
+    def test_callback_logs_inference_errors_without_logging_failure(self):
+        request = FakeInferRequest()
+        detector = self._detector([request])
+        request_id = detector._mark_request_job_started(request)
+
+        with patch("src.YOLO26OpenVINOAsyncDetector.logger.error") as error:
+            detector._callback(
+                {
+                    "request_id": request_id,
+                    "job_id": detector.job_id,
+                    "start_time": time.time(),
+                }
+            )
+
+        error.assert_called_once_with(
+            "openvino callback ignored failed/cancelled task: %s", unittest.mock.ANY
+        )
+
     @patch.object(YOLO26OpenVINOAsyncDetector, "_numpy_supports_avx2", return_value=False)
     @patch.object(YOLO26OpenVINOAsyncDetector, "_windows_supports_avx2", return_value=False)
     def test_avx2_requires_both_probes_to_report_unavailable(

--- a/tests/test_audio_routing.py
+++ b/tests/test_audio_routing.py
@@ -46,6 +46,22 @@ class AudioRoutingTests(unittest.TestCase):
 
         self.assertEqual(devices, [DEFAULT_RENDER_DEVICE, "Speakers (Realtek(R) Audio)"])
 
+    def test_switch_process_device_logs_subprocess_errors_without_logging_failure(self):
+        router = _BackgroundAudioRouter()
+        with patch.object(audio_routing, "audio_route_command", return_value=["/s"]):
+            with patch.object(
+                audio_routing.subprocess,
+                "run",
+                side_effect=RuntimeError("route failed"),
+            ):
+                with patch.object(audio_routing.logger, "error") as error:
+                    result = router._switch_process_device("svcl.exe", "Speakers")
+
+        self.assertEqual(result, "")
+        error.assert_called_once_with(
+            "failed to route game audio with svcl: %s", unittest.mock.ANY
+        )
+
     def test_parse_sound_items_csv_infers_item_fields_from_svcl_stdout(self):
         data = _parse_sound_items_csv(
             "\ufeffCommand-Line Friendly ID,Item ID,Device State,Direction,Process ID\n"


### PR DESCRIPTION
## What changed\n\n- Preserve audio routing exceptions in log messages.\n- Preserve OpenVINO callback exceptions in log messages.\n- Add regression tests for both error paths.\n\n## Root cause\n\nThe exception objects were passed as logging arguments without format placeholders, which triggered a secondary logging TypeError and hid the original error details.\n\n## Validation\n\n- 39 related unit tests passed.\n- TDD regression tests failed before the fix and passed after the fix.\n- git diff --check passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 改进推理回调、下载页面打开及音频路由失败时的错误日志记录，避免日志处理异常。
  * 音频路由失败时将稳定返回空结果，不再继续抛出异常。

* **Tests**
  * 新增推理错误回调和音频路由异常处理测试，确保错误可被正确记录并安全处理。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->