### PR TITLE
fix: serialize OpenVINO model initialization

### DIFF
--- a/src/globals.py
+++ b/src/globals.py
@@ -18,6 +18,7 @@ class Globals(QObject):
         self._periodic_tasks_lock = threading.Lock()
         exit_event.bind_stop(self)
         self._openvino_model_async = None
+        self._openvino_model_init_lock = threading.Lock()
         self._sound_context_stop_event = Event()
         threading.Thread(
             target=self.init_sound_context, daemon=True, name="SoundContextInit"
@@ -160,12 +161,14 @@ class Globals(QObject):
     @property
     def openvino_model_async(self):
         if self._openvino_model_async is None:
-            logger.info("openvino_model_async Using YOLO26OpenVINOAsyncDetector")
-            from src.YOLO26OpenVINOAsyncDetector import YOLO26OpenVINOAsyncDetector
+            with self._openvino_model_init_lock:
+                if self._openvino_model_async is None:
+                    logger.info("openvino_model_async Using YOLO26OpenVINOAsyncDetector")
+                    from src.YOLO26OpenVINOAsyncDetector import YOLO26OpenVINOAsyncDetector
 
-            self._openvino_model_async = YOLO26OpenVINOAsyncDetector(
-                xml_path=get_path_relative_to_exe("assets", "openvino", "best.xml")
-            )
+                    self._openvino_model_async = YOLO26OpenVINOAsyncDetector(
+                        xml_path=get_path_relative_to_exe("assets", "openvino", "best.xml")
+                    )
         return self._openvino_model_async
 
     @property

--- a/tests/TestGlobals.py
+++ b/tests/TestGlobals.py
@@ -1,0 +1,52 @@
+import sys
+import threading
+import time
+import types
+import unittest
+from unittest.mock import patch
+
+from src.globals import Globals
+
+
+class _FakeDetector:
+    created = 0
+    created_lock = threading.Lock()
+
+    def __init__(self, xml_path):
+        del xml_path
+        with self.created_lock:
+            type(self).created += 1
+        time.sleep(0.02)
+
+
+class TestGlobals(unittest.TestCase):
+    def test_openvino_model_is_initialized_once_when_accessed_concurrently(self):
+        _FakeDetector.created = 0
+        fake_module = types.ModuleType("src.YOLO26OpenVINOAsyncDetector")
+        fake_module.YOLO26OpenVINOAsyncDetector = _FakeDetector
+        app = Globals.__new__(Globals)
+        app._openvino_model_async = None
+        app._openvino_model_init_lock = threading.Lock()
+        start = threading.Barrier(8)
+        results = []
+
+        def get_model():
+            start.wait()
+            results.append(app.openvino_model_async)
+
+        with (
+            patch.dict(sys.modules, {"src.YOLO26OpenVINOAsyncDetector": fake_module}),
+            patch("src.globals.get_path_relative_to_exe", return_value="model.xml"),
+        ):
+            threads = [threading.Thread(target=get_model) for _ in range(8)]
+            for thread in threads:
+                thread.start()
+            for thread in threads:
+                thread.join()
+
+        self.assertEqual(_FakeDetector.created, 1)
+        self.assertEqual(len({id(model) for model in results}), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
﻿## Summary

- Serialize lazy OpenVINO detector initialization.
- Add a regression test for concurrent model access.

## Root cause

`Globals` starts background OpenVINO initialization while combat code can request the detector at the same time. The unsynchronized lazy property could construct multiple detector instances and overwrite the shared reference.

## Testing

- `.venv\Scripts\python.exe -m unittest discover -s tests -p "*test*.py" --top-level-directory . -v`
- `.venv\Scripts\python.exe -m compileall -q src tests`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - 改进 OpenVINO 检测器的并发初始化机制，避免多线程同时访问时重复创建模型。
  - 确保并发请求能够稳定复用同一个检测器实例。

- **Tests**
  - 新增并发场景测试，验证模型仅初始化一次且各线程获得一致的模型实例。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->