### PR TITLE
fix(combat): OCR 读取失败时 CD 按时间衰减而非清零

### DIFF
--- a/src/combat/BaseCombatTask.py
+++ b/src/combat/BaseCombatTask.py
@@ -343,9 +343,19 @@ class BaseCombatTask(CharElementUIMixin, CombatCheck):
         if cds is None:
             cds = {}
             self.cds[index] = cds
-        cds["time"] = time.time()
-        cds["skill"] = 0
-        cds["ultimate"] = 0
+        # Preserve previous CD values when OCR fails to read them.
+        # Instead of resetting to 0 (which falsely reports "available"),
+        # decay the last known CD by elapsed time so remaining CD stays accurate.
+        old_time = cds.get("time")
+        new_time = time.time()
+        if old_time is not None:
+            elapsed = self.time_elapsed_accounting_for_freeze(old_time)
+            cds["skill"] = max(0, cds.get("skill", 0) - elapsed)
+            cds["ultimate"] = max(0, cds.get("ultimate", 0) - elapsed)
+        else:
+            cds["skill"] = 0
+            cds["ultimate"] = 0
+        cds["time"] = new_time
         texts = self.ocr(
             0.8594, 0.8847, 0.9578, 0.9139, frame_processor=gf.isolate_text_to_black, match=cd_regex
         )

--- a/tests/TestRefreshCdDecay.py
+++ b/tests/TestRefreshCdDecay.py
@@ -1,0 +1,81 @@
+import unittest
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+from src.combat.BaseCombatTask import BaseCombatTask
+
+
+class TestRefreshCdDecay(unittest.TestCase):
+    """refresh_cd must not reset CDs to 0 when OCR reads nothing.
+
+    An OCR miss used to wipe the recorded cooldown, falsely reporting the
+    skill/ultimate as available and desynchronising the combat rotation.
+    The fix decays the last known CD by the elapsed time instead.
+    """
+
+    def setUp(self):
+        self.task = object.__new__(BaseCombatTask)
+        self.task.scene = SimpleNamespace(cd_refreshed=False)
+        self.task.cds = {}
+        self.task.get_current_char = Mock(return_value=SimpleNamespace(index=0))
+        self.task.ocr = Mock(return_value=[])
+        self.task.width_of_screen = Mock(side_effect=lambda ratio: ratio * 2560)
+        self.elapsed_mock = Mock(return_value=0.0)
+        self.task.time_elapsed_accounting_for_freeze = self.elapsed_mock
+
+    def _refresh(self, now):
+        with patch("src.combat.BaseCombatTask.time.time", return_value=now):
+            self.task.refresh_cd()
+
+    def test_ocr_failure_decays_previous_cd(self):
+        self.task.cds[0] = {"skill": 8.0, "ultimate": 30.0, "time": 100.0}
+        self.elapsed_mock.return_value = 5.0
+
+        self._refresh(now=105.0)
+
+        cds = self.task.cds[0]
+        self.assertEqual(cds["skill"], 3.0)
+        self.assertEqual(cds["ultimate"], 25.0)
+        self.assertEqual(cds["time"], 105.0)
+
+    def test_decay_floors_at_zero(self):
+        self.task.cds[0] = {"skill": 8.0, "ultimate": 30.0, "time": 100.0}
+        self.elapsed_mock.return_value = 40.0
+
+        self._refresh(now=140.0)
+
+        cds = self.task.cds[0]
+        self.assertEqual(cds["skill"], 0)
+        self.assertEqual(cds["ultimate"], 0)
+
+    def test_first_refresh_defaults_to_zero(self):
+        self._refresh(now=100.0)
+
+        cds = self.task.cds[0]
+        self.assertEqual(cds["skill"], 0)
+        self.assertEqual(cds["ultimate"], 0)
+        self.assertEqual(cds["time"], 100.0)
+
+    def test_ocr_success_overrides_decayed_value(self):
+        self.task.cds[0] = {"skill": 8.0, "ultimate": 30.0, "time": 100.0}
+        self.elapsed_mock.return_value = 5.0
+        # x=2000 < 0.89*2560 -> skill region
+        self.task.ocr.return_value = [SimpleNamespace(name="6.5", x=2000)]
+
+        self._refresh(now=105.0)
+
+        cds = self.task.cds[0]
+        self.assertEqual(cds["skill"], 6.5)
+        self.assertEqual(cds["ultimate"], 25.0)
+
+    def test_skips_when_already_refreshed(self):
+        self.task.scene.cd_refreshed = True
+
+        self.task.refresh_cd()
+
+        self.task.ocr.assert_not_called()
+        self.assertEqual(self.task.cds, {})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 问题

`refresh_cd()` 在 OCR 未读到数字时会把当前角色 `skill` / `ultimate` 的 CD 重置为 0，误报"技能就绪"。在画面特效密集或帧丢失时，这会让 planner 反复尝试实际还在冷却的技能，打乱战斗轴。

## 修复

OCR 失败时保留上次记录的 CD，并按经过时间衰减（封顶到 0）：

- 衰减复用 `time_elapsed_accounting_for_freeze`，大招动画等冻结期间不会多扣；
- OCR 成功时照常以识别值覆盖；
- 行为只在"OCR 读不到"这一帧变化，其余路径与现状完全一致。

## 测试

新增 `tests/TestRefreshCdDecay.py` 5 个用例：OCR 失败衰减、衰减封顶 0、首次刷新默认 0、OCR 成功覆盖、帧内去重跳过。本地全量测试通过。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **功能优化**
  * OCR 未识别到技能或终结技冷却时间时，系统会根据实际经过时间自动递减已有冷却值。
  * 冷却时间不会低于零；首次记录仍从零开始。
  * OCR 成功识别后，会使用最新冷却时间覆盖计算结果。
  * 已完成刷新的状态会跳过重复处理，提升运行效率。

* **测试**
  * 增加了冷却递减、首次初始化、OCR 覆盖及边界情况的测试覆盖。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->