### PR TITLE
feat(combat): 动画播放及非战斗期间抑制声音闪避反击

### DIFF
--- a/src/combat/BaseCombatTask.py
+++ b/src/combat/BaseCombatTask.py
@@ -902,6 +902,10 @@ class BaseCombatTask(CharElementUIMixin, CombatCheck):
         if not self.sleep_check_skip.check_combat:
             self.check_combat()
 
+    def can_sound_trigger(self) -> bool:
+        """Reject audio reactions while the game cannot accept a dodge input."""
+        return bool(self._in_combat and not self.in_animation)
+
     def _apply_sound_config(self, dodge_action=ACTION_UNSET, counter_action=ACTION_UNSET):
         sound_context = SoundCombatContext()
         if self.sound_config:

--- a/tests/TestCanSoundTrigger.py
+++ b/tests/TestCanSoundTrigger.py
@@ -1,0 +1,34 @@
+import unittest
+
+from src.combat.BaseCombatTask import BaseCombatTask
+
+
+class TestCanSoundTrigger(unittest.TestCase):
+    """BaseCombatTask.can_sound_trigger gates audio dodge/counter.
+
+    During an ultimate/skill animation the game does not accept a dodge
+    input, so firing one wastes the reaction; outside combat there is
+    nothing to dodge. The gate must reflect exactly that.
+    """
+
+    def setUp(self):
+        self.task = object.__new__(BaseCombatTask)
+
+    def _gate(self, in_combat, in_animation):
+        self.task._in_combat = in_combat
+        object.__setattr__(self.task, "_in_animation", in_animation)
+        return self.task.can_sound_trigger()
+
+    def test_allows_during_active_combat(self):
+        self.assertTrue(self._gate(in_combat=True, in_animation=False))
+
+    def test_rejects_during_animation(self):
+        self.assertFalse(self._gate(in_combat=True, in_animation=True))
+
+    def test_rejects_out_of_combat(self):
+        self.assertFalse(self._gate(in_combat=False, in_animation=False))
+        self.assertFalse(self._gate(in_combat=False, in_animation=True))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 问题

`BaseCombatTask` 此前没有 `can_sound_trigger` 门控（`SoundCombatContext._can_sound_trigger` 对没有该方法的 task 默认放行）。战斗任务绑定声音上下文后，即使角色处于大招/技能动画（游戏不接受闪避输入）或已离开战斗状态，音频识别仍会触发闪避/反击，造成无效输入、浪费耐力。

## 方案

在 `BaseCombatTask` 新增门控：仅在战斗中且非动画期间允许声音触发。

- 复用 `SoundCombatContext._can_sound_trigger` 现有的 `getattr` 探测机制，无需改动上下文；
- 框架层通用改动，不涉及任何角色特判；
- `SoundTriggerTask` 自身的门控不受影响。

## 测试

新增 `tests/TestCanSoundTrigger.py` 3 个用例：战斗中允许、动画期间拒绝、非战斗拒绝。本地全量测试通过。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 优化战斗中的音频反应触发逻辑：仅在角色处于战斗状态且不在动画期间时播放相关音频。
  - 非战斗状态或动画播放期间将暂停音频反应，减少不合时宜的声音反馈。

- **测试**
  - 补充多种战斗与动画状态下的触发验证，确保音频行为稳定可靠。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->