### PR TITLE
fix(sound): 修复快速连续攻击音被丢弃导致的漏闪避

### DIFF
--- a/src/sound_trigger/DodgeCounterTrigger.py
+++ b/src/sound_trigger/DodgeCounterTrigger.py
@@ -29,7 +29,11 @@ class DodgeCounterTrigger:
         self._execute_lock = threading.Lock()
         self._last_dodge_time = 0.0
         self._last_counter_time = 0.0
-        self._min_dodge_interval = 0.5
+        # Min gap between dodges. Log analysis: real attacks can come 0.343s apart
+        # (a dodge at that gap was skipped by the old 0.5s floor and the char got hit),
+        # while other dodges were >=0.509s apart. 0.3s catches rapid consecutive attacks;
+        # an occasional extra dodge on a sound echo is acceptable versus missing a real one.
+        self._min_dodge_interval = 0.3
         self._min_counter_interval = 1.0
 
     def set_actions(

--- a/src/sound_trigger/SoundCombatContext.py
+++ b/src/sound_trigger/SoundCombatContext.py
@@ -157,12 +157,19 @@ class SoundCombatContext:
             }
 
             from src.sound_trigger.SoundListener import SoundListener
+            # is_allow_successive_trigger=True disables the listener's own shared 0.5s gate
+            # (_trigger_interval). That gate silently drops a second attack sound arriving
+            # within 0.5s of the previous trigger, and dodge/counter share one
+            # _last_trigger_time. With it enabled, the per-action gates in
+            # DodgeCounterTrigger (dodge 0.3s / counter 1.0s) are the single authority.
+            # Dodge priority is untouched: _check_triggers still tests dodge first.
             self._listener = SoundListener(
                 sample_path=sample_path,
                 counter_attack_sample_path=counter_attack_sample_path,
                 threshold=threshold,
                 counter_attack_threshold=counter_attack_threshold,
                 process_name=audio_process_name,
+                is_allow_successive_trigger=True,
             )
 
             self._trigger = DodgeCounterTrigger(

--- a/tests/TestDodgeInterval.py
+++ b/tests/TestDodgeInterval.py
@@ -1,0 +1,34 @@
+import unittest
+from unittest.mock import Mock, patch
+
+from src.sound_trigger.DodgeCounterTrigger import DodgeCounterTrigger
+
+
+class TestDodgeInterval(unittest.TestCase):
+    """Rapid consecutive attacks must not be dropped by the dodge gate.
+
+    Real combat logs show enemy attacks arriving 0.343s apart; the old 0.5s
+    floor silently skipped the second dodge. The per-action gate is now 0.3s.
+    """
+
+    def setUp(self):
+        self.dodge = Mock()
+        self.trigger = DodgeCounterTrigger(task=None, dodge_action=self.dodge)
+
+    def test_dodge_0343s_apart_is_not_dropped(self):
+        with patch("src.sound_trigger.DodgeCounterTrigger.time.time", return_value=100.0):
+            self.trigger.execute_dodge()
+        with patch("src.sound_trigger.DodgeCounterTrigger.time.time", return_value=100.343):
+            self.trigger.execute_dodge()
+        self.assertEqual(self.dodge.call_count, 2)
+
+    def test_dodge_echo_within_03s_is_still_gated(self):
+        with patch("src.sound_trigger.DodgeCounterTrigger.time.time", return_value=100.0):
+            self.trigger.execute_dodge()
+        with patch("src.sound_trigger.DodgeCounterTrigger.time.time", return_value=100.2):
+            self.trigger.execute_dodge()
+        self.assertEqual(self.dodge.call_count, 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 问题

`SoundListener` 内置的共享 0.5s 触发门（`is_allow_successive_trigger=False`）会静默丢弃 0.5s 内到达的第二次攻击音，且闪避/反击共用一个 `_last_trigger_time` 互相挤占。实战日志中真实攻击最小间隔 0.343s：第二次闪避被旧 0.5s 下限跳过，角色被打。

## 方案

复用 `SoundListener` 已有的 `is_allow_successive_trigger` 参数关闭共享门，节流统一由 `DodgeCounterTrigger` 的分动作门负责：

- 闪避下限 0.5s → 0.3s（覆盖 0.343s 间隔的连续攻击）；反击 1.0s 不变；
- `_check_triggers` 闪避优先的判定顺序不受影响，单帧仍只会触发一种动作。

## 测试

新增 `tests/TestDodgeInterval.py`：0.343s 间隔的两次攻击都触发闪避；0.2s 内的回音仍被门控。本地全量测试通过。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **功能优化**
  - 缩短闪避动作的最小触发间隔，使间隔约 0.3 秒的连续攻击可分别触发闪避。
  - 保留反击动作 1 秒的触发间隔。
  - 仍会忽略 0.2 秒内的重复攻击，避免重复触发。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->