### PR TITLE
修复日常任务子任务停止后重复执行

### DIFF
--- a/src/tasks/daily/DailyRoutineTask.py
+++ b/src/tasks/daily/DailyRoutineTask.py
@@ -377,8 +377,7 @@ class DailyRoutineTask(NTEOneTimeTask, BaseNTETask):
                 entry = self.entries_by_id()[task_id]
                 if result and entry.daily_config and (shift_id := getattr(task, "shift_id", None)):
                     shift_id(task)
-        except TaskDisabledException:
-            raise
+        # Keep child stop signals as item failures so the outer one-time task can finish and disable.
         except Exception as error:
             self.log_error(f"任务运行失败: {task.name}", error)
             result = False


### PR DESCRIPTION
## 背景

日常任务中的子任务抛出 `TaskDisabledException` 时，异常会穿透 `DailyRoutineTask`。上层调度器捕获后不会禁用仍处于启用状态的外层一次性任务，导致下一轮调度再次从头执行整套日常流程。

## 修复

- 将日常任务子项抛出的 `TaskDisabledException` 按子项失败处理。
- 保持后续日常子项继续执行。
- 让外层一次性任务正常收尾并由调度器禁用。
- 避免失败后重复执行整套日常流程。

## 验证

- `.\.venv\Scripts\python.exe -m unittest tests.TestDailyRoutine`：通过，18 个测试通过。
- `.\.venv\Scripts\python.exe -m py_compile src\tasks\daily\DailyRoutineTask.py`：通过。
- `git diff --check`：通过。